### PR TITLE
Enable grpc-web streaming support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.pyc
 *_pb2.py
 *_pb2_grpc.py
+build
+bin
+out

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/grpc-web"]
+	path = third_party/grpc-web
+	url = https://github.com/grpc/grpc-web

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -17,22 +17,32 @@ init:
 	python -m pip install --upgrade pip==9.0.1
 	pip install -r $(RequirementsFile)
 
-build: proto-py
-
-proto-py:
-	cd ./protos && make
+build:
+	pushd ./protos && make proto-py && popd
 
 install-client:
-	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g -e 's,{NAME},Controller-Client,g' -e 's,{CMDLINE},'"/usr/bin/python2.7 main.py client",g template.service > /tmp/controller-client.service
+	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g \
+		-e 's,{NAME},Controller-Client,g' \
+		-e 's,{CMDLINE},'"/usr/bin/python2.7 main.py client",g \
+		-e 's,{USER},${USER},g' \
+		template.service > /tmp/controller-client.service
 	sudo mv /tmp/controller-client.service /etc/systemd/system/controller-client.service
 	sudo systemctl enable controller-client.service
 
 install-server:
-	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g -e 's,{NAME},Controller-Server,g' -e 's,{CMDLINE},'"/usr/bin/python2.7 main.py server",g template.service > /tmp/controller-server.service
+	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g \
+		-e 's,{NAME},Controller-Server,g' \
+		-e 's,{CMDLINE},'"/usr/bin/python2.7 main.py server",g \
+		-e 's,{USER},${USER},g' \
+		template.service > /tmp/controller-server.service
 	sudo mv /tmp/controller-server.service /etc/systemd/system/controller-server.service
-	sudo systemctl enable controller-server.service
+	#sudo systemctl enable controller-server.service
 
-	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g -e 's,{NAME},Nginx,g' -e 's,{CMDLINE},'"/usr/local/nginx/sbin/nginx -p /tmp -c ${SRC_DIR}/nginx.conf",g template.service > /tmp/nginx.service
+	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g \
+		-e 's,{NAME},Nginx,g' \
+		-e 's,{CMDLINE},'"/usr/local/nginx/sbin/nginx -p /tmp -c ${SRC_DIR}/nginx.conf",g \
+		-e 's,{USER},${USER},g' \
+		template.service > /tmp/nginx.service
 	sudo mv /tmp/nginx.service /etc/systemd/system/nginx.service
 	sudo systemctl enable nginx.service
 

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -14,10 +14,8 @@ endif
 SRC_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 init:
-	python -m pip install --upgrade pip
+	python -m pip install --upgrade pip==9.0.1
 	pip install -r $(RequirementsFile)
-	# For gRPC-web support
-	sudo apt-get install nginx
 
 build: proto-py
 
@@ -25,14 +23,18 @@ proto-py:
 	cd ./protos && make
 
 install-client:
-	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g -e s/{TYPE}/client/g template.service > /tmp/controller-client.service
+	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g -e 's,{NAME},Controller-Client,g' -e 's,{CMDLINE},'"/usr/bin/python2.7 main.py client",g template.service > /tmp/controller-client.service
 	sudo mv /tmp/controller-client.service /etc/systemd/system/controller-client.service
 	sudo systemctl enable controller-client.service
 
 install-server:
-	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g -e s/{TYPE}/server/g template.service > /tmp/controller-server.service
+	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g -e 's,{NAME},Controller-Server,g' -e 's,{CMDLINE},'"/usr/bin/python2.7 main.py server",g template.service > /tmp/controller-server.service
 	sudo mv /tmp/controller-server.service /etc/systemd/system/controller-server.service
 	sudo systemctl enable controller-server.service
+
+	sed -e 's,{SRC_DIR},'"$(SRC_DIR)",g -e 's,{NAME},Nginx,g' -e 's,{CMDLINE},'"/usr/local/nginx/sbin/nginx -p /tmp -c ${SRC_DIR}/nginx.conf",g template.service > /tmp/nginx.service
+	sudo mv /tmp/nginx.service /etc/systemd/system/nginx.service
+	sudo systemctl enable nginx.service
 
 run-client: build
 	python main.py

--- a/controller/common/pattern.py
+++ b/controller/common/pattern.py
@@ -54,7 +54,7 @@ class Logger(object):
   """
 
   def __init__(self, *args, **kwargs):
-    super(Logger, self).__init__()
+    super(Logger, self).__init__(*args, **kwargs)
     self._logger = logging.getLogger(self.__class__.__name__)
 
   @property

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -14,6 +14,7 @@
 """gRPC service handler and client warapper for server-client communications."""
 
 import grpc
+import Queue
 import threading
 from google.protobuf import empty_pb2
 
@@ -100,24 +101,43 @@ class ControlService(controller_pb2_grpc.ControlServiceServicer,
       settings.status = status
       component.status = component_status.status
 
+      for queue in self._notification_queues:
+        self.logger.info('Notifying clients watching for status...')
+        try:
+          queue.put(component_status, block=False)
+        except Queue.Full:
+          pass
+
     self.emit('status_changed')
 
     return empty_pb2.Empty()
 
   def WatchStatus(self, _, context):
-    queue = Queue.Queue()
+    """Handler for WatchStatus gRPC call.
+
+    This handler streams component status update from server to client.
+
+    Args:
+      context: gRPC context.
+    Yields:
+      flightlab.ComponentStatus.
+    """
+    self.logger.info('New client starts to watch status...')
+    queue = Queue.Queue(maxsize=100)
     self._notification_queues.append(queue)
     try:
       while not self._stopped:
         try:
-          yield queue.get(block=true, timeout=1)
+          status = queue.get(block=True, timeout=1)
+          self.logger.info('Notifying client status change...')
+          yield status
         except Queue.Empty:
           pass
     finally:
       self._notification_queues.remove(queue)
 
-  def Watch(self, machine_id, context):
-    """Handler for Watch gRPC call.
+  def WatchCommand(self, machine_id, context):
+    """Handler for WatchCommand gRPC call.
 
     This handler streams commands from server to client.
 
@@ -261,7 +281,7 @@ class ControlClient(pattern.Logger):
     """Attempt to reconnect to server and retry after an interval if fails."""
     self._thread = None
     try:
-      response = self._stub.Watch(
+      response = self._stub.WatchCommand(
           controller_pb2.MachineId(name=self._machine_config.name))
       self._thread = threading.Thread(
           target=self._watch, kwargs={

--- a/controller/nginx.conf
+++ b/controller/nginx.conf
@@ -1,0 +1,42 @@
+master_process off;
+daemon off;
+worker_processes 1;
+pid nginx.pid;
+error_log stderr debug;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  access_log off;
+  client_max_body_size 0;
+  client_body_temp_path client_body_temp;
+  proxy_temp_path proxy_temp;
+  proxy_request_buffering off;
+  server {
+    listen 8000;
+    server_name localhost;
+    location ~ \.(html|js)$ {
+      root /var/www/html;
+    }
+    location / {
+      grpc_pass localhost:9000;
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Transfer-Encoding,Custom-Header-1,X-Accept-Content-Transfer-Encoding,X-Accept-Response-Streaming,X-User-Agent,X-Grpc-Web';
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Content-Type' 'text/plain charset=UTF-8';
+        add_header 'Content-Length' 0;
+        return 204;
+      }
+      if ($request_method = 'POST') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Transfer-Encoding,Custom-Header-1,X-Accept-Content-Transfer-Encoding,X-Accept-Response-Streaming,X-User-Agent,X-Grpc-Web';
+        add_header 'Access-Control-Expose-Headers' 'Content-Transfer-Encoding';
+      }
+    }
+  }
+}

--- a/controller/protos/Makefile
+++ b/controller/protos/Makefile
@@ -1,5 +1,40 @@
-all: proto
+SRC_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT_DIR = $(SRC_DIR)/../..
+PROTOC = protoc
+CLOSURE_COMPILER = $(ROOT_DIR)/bin/closure-compiler.jar
+GRPC_WEB_PATH = $(ROOT_DIR)/third_party/grpc-web
+PROTOBUF_PATH = $(GRPC_WEB_PATH)/third_party/grpc/third_party/protobuf
+CLOSURE_LIBRARY_PATH = $(GRPC_WEB_PATH)/third_party/closure-library
+GRPC_WEB_PLUGIN_PATH = $(GRPC_WEB_PATH)/javascript/net/grpc/web/protoc-gen-grpc-web
+OUT_DIR = ../out
+BUILD_DIR = ../build
+JS_IMPORT_STYLE = import_style=closure,binary
 
-proto:
+all: proto-py compiled-js
+
+proto-py:
 	python -m grpc_tools.protoc -I./ --python_out=. --grpc_python_out=. client.proto
 	python -m grpc_tools.protoc -I./ --python_out=. --grpc_python_out=. controller.proto
+
+proto-js:
+	rm -rf $(OUT_DIR)
+	mkdir -p $(OUT_DIR)
+	$(PROTOC) -I=$(PROTOBUF_PATH)/src/google/protobuf --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) $(PROTOBUF_PATH)/src/google/protobuf/any.proto
+	$(PROTOC) -I=$(PROTOBUF_PATH)/src/google/protobuf --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) $(PROTOBUF_PATH)/src/google/protobuf/empty.proto
+	$(PROTOC) -I=$(GRPC_WEB_PATH)/net/grpc/gateway/protos --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) $(GRPC_WEB_PATH)/net/grpc/gateway/protos/stream_body.proto
+	$(PROTOC) -I=$(GRPC_WEB_PATH)/net/grpc/gateway/protos --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) $(GRPC_WEB_PATH)/net/grpc/gateway/protos/pair.proto
+	$(PROTOC) -I=./ --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) ./controller.proto
+	$(PROTOC) -I=./ --plugin=protoc-gen-grpc-web=$(GRPC_WEB_PLUGIN_PATH) --grpc-web_out=import_style=closure,mode=grpcwebtext:$(OUT_DIR) ./controller.proto
+
+compiled-js: proto-js
+	mkdir -p $(BUILD_DIR)
+	java \
+		-jar $(CLOSURE_COMPILER) \
+		--js $(GRPC_WEB_PATH)/javascript \
+  		--js $(GRPC_WEB_PATH)/net \
+  		--js $(CLOSURE_LIBRARY_PATH) \
+  		--js $(PROTOBUF_PATH)/js \
+  		--js $(OUT_DIR) \
+  		--entry_point=goog:proto.flightlab.ControlServiceClient \
+  		--dependency_mode=STRICT \
+  		--js_output_file $(BUILD_DIR)/controller.js

--- a/controller/protos/controller.proto
+++ b/controller/protos/controller.proto
@@ -176,7 +176,7 @@ service ControlService {
   // Listens to status of components from server.
   rpc WatchStatus(google.protobuf.Empty) returns (stream ComponentStatus);
   // Listens to command from server.
-  rpc Watch(MachineId) returns (stream SystemCommand);
+  rpc WatchCommand(MachineId) returns (stream SystemCommand);
 }
 
 // Client identification.

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -2,6 +2,7 @@ cherrypy==10.2.1
 enum
 flask
 flask-cors
+google-apputils
 grpcio-tools
 netifaces
 playsound

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -7,3 +7,4 @@ netifaces
 playsound
 psutil
 pyserial
+python-gflags

--- a/controller/template.service
+++ b/controller/template.service
@@ -3,12 +3,12 @@ Description={NAME}
 After=network.target
 
 [Service]
-ExecStart={CMDLINE} > /var/log/{NAME}.log 2>&1
+ExecStart={CMDLINE}
 WorkingDirectory={SRC_DIR}
 StandardOutput=inherit
 StandardError=inherit
 Restart=always
-User=pi
+User={USER}
 
 [Install]
 WantedBy=multi-user.target

--- a/controller/template.service
+++ b/controller/template.service
@@ -1,9 +1,9 @@
 [Unit]
-Description=Controller {TYPE}
+Description={NAME}
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/python2.7 main.py {TYPE} > /var/log/controller-{TYPE}.log 2>&1
+ExecStart={CMDLINE} > /var/log/{NAME}.log 2>&1
 WorkingDirectory={SRC_DIR}
 StandardOutput=inherit
 StandardError=inherit

--- a/controller/testing/control_service_test.html
+++ b/controller/testing/control_service_test.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+	<script src="../build/controller.js"></script>
+</head>
+<body>
+	<div id="Log"></div>
+	<script>
+		var logElement = document.getElementById('Log');
+		var service = new proto.flightlab.ControlServiceClient('http://127.0.0.1:8000');
+		var stream = this.service.watchStatus(new proto.google.protobuf.Empty(), {});
+		var statusUpdates = [];
+		stream.on('data', function(componentStatus) {
+			statusUpdates.push(componentStatus);
+			console.log(componentStatus);
+
+			var div = document.createElement('div');
+			div.innerText = `${componentStatus.getName()}: ${componentStatus.getStatus()}`;
+			logElement.appendChild(div);
+		});
+	</script>
+</body>
+</html>


### PR DESCRIPTION
This change enables web client to stream component status updates via grpc-web.

Example:
  1. Start controller server
  2. Start controller client
  3. Open controller/testing/control_service_test.html in browser
  4. Make a component status change (such as turn on/off system)
  5. The page will show streamed updates as well as logging it in console.