### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/controller/testing/client_service_test.py
+++ b/controller/testing/client_service_test.py
@@ -21,6 +21,11 @@ from google.protobuf import empty_pb2
 from protos import client_pb2
 from protos import client_pb2_grpc
 
+try:
+  raw_input          # Python 2
+except NameError:
+  raw_input = input  # Python 3
+
 
 def test_image_display(argv):
   """Test image display on client machine.

--- a/controller/utils/badger.py
+++ b/controller/utils/badger.py
@@ -56,7 +56,7 @@ class BadgeValidator(pattern.EventEmitter):
       r = requests.get(url = self._url, params = {self._key_param: badge_id})
       return r.status_code >= 200 and r.status_code < 300
     except requests.ConnectionError:
-      return false
+      return False
 
 class BadgeReader(pattern.Worker, pattern.EventEmitter):
   """Worker that monitors the badge reader and emits the badge ID on success.

--- a/controller/utils/display_test.py
+++ b/controller/utils/display_test.py
@@ -16,6 +16,11 @@ import os
 
 from utils import display
 
+try:
+  raw_input          # Python 2
+except NameError:
+  raw_input = input  # Python 3
+
 
 def test():
   test_message = 'Hello World!'

--- a/controller/utils/light.py
+++ b/controller/utils/light.py
@@ -20,6 +20,11 @@ import struct
 
 from common import pattern
 
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 
 class Dmx(pattern.Closable, pattern.Logger):
   """Class for controlling DMX lights.

--- a/controller/utils/projector.py
+++ b/controller/utils/projector.py
@@ -164,7 +164,7 @@ class ProjectorController(object):
       if self._password is None:
         raise ProjectorException('Projector requires a password.')
 
-      pass_data = (salt + password).encode('utf-8')
+      pass_data = (salt + self._password).encode('utf-8')
       pass_data_md5 = hashlib.md5(pass_data).hexdigest()
 
       self._send_command(cmd='POWR', param='?', prefix=pass_data_md5)

--- a/controller/utils/projector_test.py
+++ b/controller/utils/projector_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test-cases for utils.Projector."""
+from __future__ import print_function
 
 import logging
 import sys
@@ -30,19 +31,19 @@ def test(argv):
       try:
         p.power_on()
       except Exception as e:
-        print e
+        print(e)
     elif cmd == 'off':
       try:
         p.power_off()
       except Exception as e:
-        print e
+        print(e)
     elif cmd == 'exit':
       break
   p.stop()
 
 
 def on_state_changed(old_state, new_state):
-  print 'State changed: "{0}" => "{1}"'.format(old_state, new_state)
+  print('State changed: "{0}" => "{1}"'.format(old_state, new_state))
 
 
 if __name__ == '__main__':

--- a/controller/utils/projector_test.py
+++ b/controller/utils/projector_test.py
@@ -19,6 +19,11 @@ import sys
 
 import projector
 
+try:
+  raw_input          # Python 2
+except NameError:
+  raw_input = input  # Python 3
+
 
 def test(argv):
   ip = argv[1]


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

__raw_input()__ and __xrange()__ were removed in Python 3.